### PR TITLE
Fix for issue #65

### DIFF
--- a/scripts/modals/ModalAbilityCheck.js
+++ b/scripts/modals/ModalAbilityCheck.js
@@ -61,12 +61,14 @@ const ModalAbilityCheck = (function() {
 		}
 
 		try {
-			const roll = new Roll(RollFormula.getRollFormula(rollString)).roll();
-			roll.toMessage({
-				speaker: ChatMessage.getSpeaker({actor: this.actor}),
-				flavor: messageParts.join(" "),
-				messageData: {"flags.dnd5e.roll": {type: "other", itemId: this.id }},
-				rollMode: form.get("mode")
+			const asyncRoll = new Roll(RollFormula.getRollFormula(rollString)).roll();
+			asyncRoll.then(completedRoll => {
+				completedRoll.toMessage({
+					speaker: ChatMessage.getSpeaker({actor: this.actor}),
+					flavor: messageParts.join(" "),
+					messageData: {"flags.dnd5e.roll": {type: "other", itemId: this.id }},
+					rollMode: form.get("mode")
+				})
 			});
 			modal.querySelector("[data-action='close-modal']").click();
 		} catch(err) {

--- a/scripts/modals/ModalBasicAttackAc.js
+++ b/scripts/modals/ModalBasicAttackAc.js
@@ -38,12 +38,14 @@ const ModalBasicAttackAc = (function() {
 		}
 
 		try {
-			const roll = new Roll(RollFormula.getRollFormula(rollString)).roll();
-			roll.toMessage({
-				speaker: ChatMessage.getSpeaker({actor: this.actor}),
-				flavor: messageParts.join(" "),
-				messageData: {"flags.dnd5e.roll": {type: "other", itemId: this.id }},
-				rollMode: form.get("mode")
+			const asyncRoll = new Roll(RollFormula.getRollFormula(rollString)).roll();
+			asyncRoll.then(completedRoll => {
+				completedRoll.toMessage({
+					speaker: ChatMessage.getSpeaker({actor: this.actor}),
+					flavor: messageParts.join(" "),
+					messageData: {"flags.dnd5e.roll": {type: "other", itemId: this.id }},
+					rollMode: form.get("mode")
+				})
 			});
 			modal.querySelector("[data-action='close-modal']").click();
 		} catch(err) {

--- a/scripts/modals/ModalBasicAttackSave.js
+++ b/scripts/modals/ModalBasicAttackSave.js
@@ -39,12 +39,14 @@ const ModalBasicAttackAc = (function() {
 		}
 
 		try {
-			const roll = new Roll(RollFormula.getRollFormula(rollString)).roll();
-			roll.toMessage({
-				speaker: ChatMessage.getSpeaker({actor: this.actor}),
-				flavor: messageParts.join(" "),
-				messageData: {"flags.dnd5e.roll": {type: "other", itemId: this.id }},
-				rollMode: form.get("mode")
+			const asyncRoll = new Roll(RollFormula.getRollFormula(rollString)).roll();
+			asyncRoll.then(completedRoll => {
+				completedRoll.toMessage({
+					speaker: ChatMessage.getSpeaker({actor: this.actor}),
+					flavor: messageParts.join(" "),
+					messageData: {"flags.dnd5e.roll": {type: "other", itemId: this.id }},
+					rollMode: form.get("mode")
+				})
 			});
 			modal.querySelector("[data-action='close-modal']").click();
 		} catch(err) {

--- a/scripts/modals/ModalBasicDamage.js
+++ b/scripts/modals/ModalBasicDamage.js
@@ -46,12 +46,14 @@ const ModalBasicDamage = (function() {
 		}
 
 		try {
-			const roll = new Roll(RollFormula.getRollFormula(rollString)).roll();
-			roll.toMessage({
-				speaker: ChatMessage.getSpeaker({actor: this.actor}),
-				flavor: messageParts.join(" "),
-				messageData: {"flags.dnd5e.roll": {type: "other", itemId: this.id }},
-				rollMode: form.get("mode")
+			const asyncRoll = new Roll(RollFormula.getRollFormula(rollString)).roll();
+			asyncRoll.then(completedRoll => {
+				completedRoll.toMessage({
+					speaker: ChatMessage.getSpeaker({actor: this.actor}),
+					flavor: messageParts.join(" "),
+					messageData: {"flags.dnd5e.roll": {type: "other", itemId: this.id }},
+					rollMode: form.get("mode")
+				})
 			});
 			modal.querySelector("[data-action='close-modal']").click();
 		} catch(err) {

--- a/scripts/modals/ModalSavingThrow.js
+++ b/scripts/modals/ModalSavingThrow.js
@@ -53,12 +53,14 @@ const ModalSavingThrow = (function() {
 		}
 
 		try {
-			const roll = new Roll(RollFormula.getRollFormula(rollString)).roll();
-			roll.toMessage({
-				speaker: ChatMessage.getSpeaker({actor: this.actor}),
-				flavor: messageParts.join(" "),
-				messageData: {"flags.dnd5e.roll": {type: "other", itemId: this.id }},
-				rollMode: form.get("mode")
+			const asyncRoll = new Roll(RollFormula.getRollFormula(rollString)).roll();
+			asyncRoll.then(completedRoll => {
+				completedRoll.toMessage({
+					speaker: ChatMessage.getSpeaker({actor: this.actor}),
+					flavor: messageParts.join(" "),
+					messageData: {"flags.dnd5e.roll": {type: "other", itemId: this.id }},
+					rollMode: form.get("mode")
+				})
 			});
 			modal.querySelector("[data-action='close-modal']").click();
 		} catch(err) {


### PR DESCRIPTION
This is a fix for issue [[65](https://github.com/giffyglyph/foundry-5e-monster-maker/issues/65)]

In foundry 1.9, the `Roll` object's `roll()` method was converted to an `async` method that returned a `Promise<Roll>` instead of just a `Roll`. Correcting the issue just involved calling `.then(resultingRoll => {...})` to let the script access the result of the `Roll` object so it could call `Roll.toMessage()` (instead of calling `Promise<Roll>.toMessage()`, which is what's been generating the UI error we've been seeing).